### PR TITLE
Change sidebar background color

### DIFF
--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -350,7 +350,7 @@
         </div>
         
         <!-- Quick Actions -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+        <div class="quick-actions-grid mb-8">
             <button id="addTransactionBtn" class="quick-action-btn">
                 <div class="flex items-center justify-between">
                     <div>
@@ -363,7 +363,7 @@
                     <i class="fas fa-arrow-right text-xl"></i>
                 </div>
             </button>
-            
+
             <button id="viewReportsBtn" class="quick-action-btn reports">
                 <div class="flex items-center justify-between">
                     <div>
@@ -412,7 +412,7 @@
                         <p class="text-2xl font-bold text-gray-900" id="totalRevenue">R$ 0,00</p>
                     </div>
                 </div>
-                <div class="text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded">
+                <div class="text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded no-data">
                     <i class="fas fa-minus mr-1"></i>
                     Sem dados do mês anterior
                 </div>
@@ -428,7 +428,7 @@
                         <p class="text-2xl font-bold text-gray-900" id="totalExpenses">R$ 0,00</p>
                     </div>
                 </div>
-                <div class="text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded">
+                <div class="text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded no-data">
                     <i class="fas fa-minus mr-1"></i>
                     Sem dados do mês anterior
                 </div>
@@ -444,7 +444,7 @@
                         <p class="text-2xl font-bold text-gray-900" id="totalProfit">R$ 0,00</p>
                     </div>
                 </div>
-                <div class="text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded">
+                <div class="text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded no-data">
                     <i class="fas fa-minus mr-1"></i>
                     Sem dados do mês anterior
                 </div>

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@
 .sidebar {
   width: var(--sidebar-width);
   background: #f0f4f8;
-  color: var(--light-text);
+  color: var(--primary-color);
   position: fixed;
   height: 100vh;
   left: 0;
@@ -49,7 +49,7 @@
   font-size: 1.5rem;
   font-weight: 700;
   letter-spacing: 0.5px;
-  color: var(--light-text);
+  color: var(--primary-color);
   text-shadow: 0px 2px 4px rgba(0,0,0,0.3);
 }
 
@@ -69,25 +69,35 @@
 
 /* Menu de Navegação */
 .sidebar-nav-item {
+  position: relative;
   display: flex;
   align-items: center;
   padding: 1rem 1.5rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--primary-color);
   transition: var(--transition-standard);
-  border-left: 3px solid transparent;
   margin: 0.25rem 0;
 }
 
-.sidebar-nav-item:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: white;
-  border-left: 3px solid var(--secondary-color);
+.sidebar-nav-item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  background: var(--secondary-color);
+  transition: width 0.3s ease;
 }
 
+.sidebar-nav-item:hover::before,
+.sidebar-nav-item.active::before {
+  width: 4px;
+}
+
+.sidebar-nav-item:hover,
 .sidebar-nav-item.active {
-  background-color: rgba(255, 255, 255, 0.15);
-  color: white;
-  border-left: 3px solid var(--secondary-color);
+  background-color: rgba(9, 177, 136, 0.1);
+  color: var(--primary-color);
 }
 
 .sidebar-nav-icon {
@@ -110,17 +120,18 @@
   width: 100%;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   font-size: 0.875rem;
+  color: var(--primary-color);
 }
 
 .logout-button {
   display: flex;
   align-items: center;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--primary-color);
   transition: var(--transition-standard);
 }
 
 .logout-button:hover {
-  color: white;
+  color: var(--primary-color);
 }
 
 .logout-icon {
@@ -1201,7 +1212,7 @@
 @media (min-width: 768px) {
     .sidebar {
         width: 280px;
-        background: linear-gradient(to bottom, #0c2e69, #041c44);
+        background: #f0f4f8;
         position: fixed;
         height: 100vh;
         left: 0;
@@ -1222,7 +1233,7 @@
         display: flex;
         align-items: center;
         padding: 1rem 1.5rem;
-        color: rgba(255, 255, 255, 0.8);
+        color: var(--primary-color);
         text-decoration: none;
         transition: all 0.3s ease;
         border-left: 3px solid transparent;
@@ -1231,7 +1242,7 @@
     .nav-item:hover,
     .nav-item.active {
         background-color: rgba(255, 255, 255, 0.1);
-        color: white;
+        color: var(--primary-color);
         border-left-color: #09b188;
     }
     
@@ -1338,7 +1349,7 @@
     background: linear-gradient(135deg, #09b188, #08a078);
     color: white;
     border-radius: 1rem;
-    padding: 1.5rem;
+    padding: 1.25rem;
     transition: all 0.3s ease;
     border: none;
     cursor: pointer;
@@ -1353,6 +1364,27 @@
 .quick-action-btn:hover {
     transform: translateY(-2px);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+}
+
+.quick-actions-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+}
+
+@media (max-width: 767px) {
+    .quick-action-btn {
+        padding: 0.75rem;
+    }
+
+    .quick-action-btn i {
+        font-size: 1.25rem;
+    }
+
+    .quick-actions-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.75rem;
+    }
 }
 
 /* Correções para dropdown do usuário */
@@ -1466,6 +1498,16 @@
 .stats-card:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     transform: translateY(-1px);
+}
+
+.stats-card .no-data {
+    margin-top: 0.5rem;
+}
+
+@media (max-width: 767px) {
+    .stats-card .no-data {
+        display: none;
+    }
 }
 
 /* Garantir que notificações apareçam acima de tudo */


### PR DESCRIPTION
## Summary
- use light gray sidebar background on desktop view
- switch sidebar text to primary dark blue
- add sliding highlight for sidebar links
- place quick action buttons in a grid and shrink them on mobile
- hide empty monthly summary in mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ef95c154c8323925b36a68abbfe03